### PR TITLE
Julian - Fix docker compose to run cross-platform

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,8 @@ services:
     ports:
       - "3000:3000"
     volumes:
-      - /Users/all/logs:/var/src/allmende-server/logs
-      - /Users/all/allmende-uploads:/var/src/allmende-serer/uploads
+      - allmende:/var/src/allmende-server/logs
+      - allmende:/var/src/allmende-serer/uploads
     environment:
       MONGO_USER: admin
       MONGO_PW: password
@@ -31,5 +31,6 @@ services:
     ports:
       - "6379:6379"
     volumes:
-      - /Users/all/redis:/data
-    
+      - allmende:/data
+volumes:
+  allmende:


### PR DESCRIPTION
I wasn't able to start the server with the current docker-compose file. The error message was something like: `The heck is /Users/all`.

In previous projects, we always told Docker to create a new volume on which the data is saved. I copied that approach and it seems to work for me. I don't know if this is the best approach, but it should work across systems. Maybe @davidmllr know more about that?

Also, fyi: This will probably reset your server state once, when merged.