### PR TITLE
Support for .env file

### DIFF
--- a/server/example.env
+++ b/server/example.env
@@ -1,0 +1,7 @@
+## MongoDB credentials
+MONGO_USER=admin
+MONGO_PW=password
+MONGO_HOST=localhost
+
+## Redis credentials
+REDIS_HOST=localhost

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -47,6 +47,7 @@
         "@types/uuid": "^8.3.4",
         "@typescript-eslint/eslint-plugin": "^5.20.0",
         "@typescript-eslint/parser": "^5.20.0",
+        "dotenv-cli": "^5.1.0",
         "eslint": "^8.13.0",
         "eslint-config-prettier": "^8.5.0",
         "jest": "^27.5.1",
@@ -3323,6 +3324,39 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.1.tgz",
+      "integrity": "sha512-1K6hR6wtk2FviQ4kEiSjFiH5rpzEVi8WW0x96aztHVMhEspNpc4DVOUTEHtEva5VThQ8IaBX1Pe4gSzpVVUsKQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/dotenv-cli": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/dotenv-cli/-/dotenv-cli-5.1.0.tgz",
+      "integrity": "sha512-NoEZAlKo9WVrG0b3i9mBxdD6INdDuGqdgR74t68t8084QcI077/1MnPerRW1odl+9uULhcdnQp2U0pYVppKHOA==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "dotenv": "^16.0.0",
+        "dotenv-expand": "^8.0.1",
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "dotenv": "cli.js"
+      }
+    },
+    "node_modules/dotenv-expand": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-8.0.3.tgz",
+      "integrity": "sha512-SErOMvge0ZUyWd5B0NXMQlDkN+8r+HhVUsxgOO7IoPDOdDRD2JjExpN6y3KnFR66jsJMwSn1pqIivhU5rcJiNg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/duplexer3": {
@@ -11466,6 +11500,30 @@
       "requires": {
         "is-obj": "^2.0.0"
       }
+    },
+    "dotenv": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.1.tgz",
+      "integrity": "sha512-1K6hR6wtk2FviQ4kEiSjFiH5rpzEVi8WW0x96aztHVMhEspNpc4DVOUTEHtEva5VThQ8IaBX1Pe4gSzpVVUsKQ==",
+      "dev": true
+    },
+    "dotenv-cli": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/dotenv-cli/-/dotenv-cli-5.1.0.tgz",
+      "integrity": "sha512-NoEZAlKo9WVrG0b3i9mBxdD6INdDuGqdgR74t68t8084QcI077/1MnPerRW1odl+9uULhcdnQp2U0pYVppKHOA==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.3",
+        "dotenv": "^16.0.0",
+        "dotenv-expand": "^8.0.1",
+        "minimist": "^1.2.5"
+      }
+    },
+    "dotenv-expand": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-8.0.3.tgz",
+      "integrity": "sha512-SErOMvge0ZUyWd5B0NXMQlDkN+8r+HhVUsxgOO7IoPDOdDRD2JjExpN6y3KnFR66jsJMwSn1pqIivhU5rcJiNg==",
+      "dev": true
     },
     "duplexer3": {
       "version": "0.1.4",

--- a/server/package.json
+++ b/server/package.json
@@ -4,9 +4,9 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "jest",
-    "start": "node dist/index.js",
-    "dev": "nodemon",
+    "test": "dotenv -- jest",
+    "start": "dotenv -- node dist/index.js",
+    "dev": "dotenv -- nodemon",
     "prettier": "prettier --write .",
     "prettier-watch": "onchange \"**/*\" -- prettier --write --ignore-unknown {{changed}}",
     "build": "tsc"
@@ -53,6 +53,7 @@
     "@types/uuid": "^8.3.4",
     "@typescript-eslint/eslint-plugin": "^5.20.0",
     "@typescript-eslint/parser": "^5.20.0",
+    "dotenv-cli": "^5.1.0",
     "eslint": "^8.13.0",
     "eslint-config-prettier": "^8.5.0",
     "jest": "^27.5.1",

--- a/server/src/config/db.ts
+++ b/server/src/config/db.ts
@@ -3,9 +3,9 @@ import { connect, ConnectOptions } from "mongoose";
 import redis from "ioredis";
 // import { Logger } from "../lib";
 
-const MONGO_USER = process.env.NODE_ENV !== "production" ? "admin" : process.env.MONGO_USER;
-const MONGO_PW = process.env.NODE_ENV !== "production" ? "password" : process.env.MONGO_PW;
-const MONGO_HOST = process.env.NODE_ENV !== "production" ? "localhost" : process.env.MONGO_HOST;
+const MONGO_USER = process.env.MONGO_USER || "admin";
+const MONGO_PW = process.env.MONGO_PW || "password";
+const MONGO_HOST = process.env.MONGO_HOST || "localhost";
 const MONGO_PORT = 27017;
 
 export const connectString = `mongodb://${MONGO_USER}:${MONGO_PW}@${MONGO_HOST}:${MONGO_PORT}`;


### PR DESCRIPTION
As I said on Discord, I have a bit of an exotic setup, so having support for an optional .env file during development would be nice.

The patch doesn't change anything really, when you don't have an .env file. You just need to do `npm install` once to get the new dev-dependency.